### PR TITLE
Wrap the docstring of cython-default-compile-format to 80 characters

### DIFF
--- a/cython-mode.el
+++ b/cython-mode.el
@@ -108,7 +108,8 @@
 ;;;###autoload
 (defcustom cython-default-compile-format "cython -a %s"
   "Format for the default command to compile a Cython file.
-It will be passed to `format' with `buffer-file-name' as the only other argument."
+It will be passed to `format' with `buffer-file-name'
+as the only other argument."
   :group 'cython
   :type 'string)
 


### PR DESCRIPTION
This should avoid a warning as reported in:
https://bugzilla.redhat.com/show_bug.cgi?id=2155090

:warning: I am doing this in the web editor and I have no idea how this file works.